### PR TITLE
Legger til støtte for gruppering av repos pr eier

### DIFF
--- a/src/components/OrganizationsOnGithub.tsx
+++ b/src/components/OrganizationsOnGithub.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import organizations from "./data/organizations.json";
 import getNumberOfPublicRepos from "../app/api/github";
 
@@ -17,6 +17,12 @@ type OrganizationsWithRepos = {
     url: string;
     owner: string;
     repos: number
+}
+
+type GroupedOrganization = {
+    name: string;
+    totalRepos: number;
+    orgs: OrganizationsWithRepos[];
 }
 
 export const OrganizationsOnGithub = () => {
@@ -39,7 +45,23 @@ export const OrganizationsOnGithub = () => {
                 })));
     }, []);
 
-    const organizationsWithReposByRepoNumber: OrganizationsWithRepos[] = organizationsWithRepos.sort((a, b) => b.repos - a.repos)
+    const groupedOrganizations: GroupedOrganization[] = useMemo(() => {
+        const groupMap = new Map<string, GroupedOrganization>();
+        for (const org of organizationsWithRepos) {
+            const existing = groupMap.get(org.name);
+            if (existing) {
+                existing.totalRepos += org.repos;
+                existing.orgs.push(org);
+            } else {
+                groupMap.set(org.name, {
+                    name: org.name,
+                    totalRepos: org.repos,
+                    orgs: [org],
+                });
+            }
+        }
+        return Array.from(groupMap.values()).sort((a, b) => b.totalRepos - a.totalRepos);
+    }, [organizationsWithRepos]);
 
 
     return (
@@ -56,7 +78,7 @@ export const OrganizationsOnGithub = () => {
                 on
                 GitHub</h1>
             {
-                organizationsWithReposByRepoNumber &&
+                groupedOrganizations &&
                 <table className="w-full text-sm text-left rtl:text-right">
                     <thead className="text-m uppercase">
                     <tr>
@@ -66,15 +88,27 @@ export const OrganizationsOnGithub = () => {
                     </tr>
                     </thead>
                     <tbody>
- {organizationsWithReposByRepoNumber.map((organization, idx) =>
-    <tr className="border-b dark:border-gray-700" key={organization.id}>
+ {groupedOrganizations.map((group, idx) =>
+    <tr className="border-b dark:border-gray-700" key={group.name}>
         <td className="px-3 py-4">{idx + 1}</td>
         <td className="px-3 py-4">
-            <a className="text-blue-600 dark:text-blue-500 hover:underline"
-               href={organization.url}>{organization.name}</a>
+            {group.orgs.length === 1 ? (
+                <a className="text-blue-600 dark:text-blue-500 hover:underline"
+                   href={group.orgs[0].url}>{group.name}</a>
+            ) : (
+                <div>
+                    <span className="text-blue-600 dark:text-blue-500">{group.name}</span>
+                    <div className="mt-1 flex flex-wrap gap-x-2 text-xs">
+                        {group.orgs.map((org) => (
+                            <a key={org.id} className="text-blue-600 dark:text-blue-500 hover:underline"
+                               href={org.url}>{org.owner}</a>
+                        ))}
+                    </div>
+                </div>
+            )}
         </td>
         <td className="px-3 py-4">
-            {organization.repos}
+            {group.totalRepos}
         </td>
     </tr>
 )}

--- a/src/components/__tests__/OrganizationsOnGithub.test.tsx
+++ b/src/components/__tests__/OrganizationsOnGithub.test.tsx
@@ -11,6 +11,8 @@ jest.mock('../../app/api/github', () => ({
 jest.mock('../data/organizations.json', () => [
     {id: 1, name: 'Nav Teknologiavdelingen', url: 'https://github.com/navikt', owner: 'navikt'},
     {id: 2, name: 'Skatteetaten', url: 'https://github.com/skatteetaten', owner: 'skatteetaten'},
+    {id: 3, name: 'Statens vegvesen', url: 'https://github.com/nvdb-vegdata', owner: 'nvdb-vegdata'},
+    {id: 4, name: 'Statens vegvesen', url: 'https://github.com/vegvesen', owner: 'vegvesen'},
 ])
 
 const mockGetNumberOfPublicRepos = jest.mocked(getNumberOfPublicRepos)
@@ -39,9 +41,7 @@ describe('OrganizationsOnGithub', () => {
     })
 
     it('renders organizations with repo counts after data loads', async () => {
-        mockGetNumberOfPublicRepos
-            .mockResolvedValueOnce(100)
-            .mockResolvedValueOnce(50)
+        mockGetNumberOfPublicRepos.mockResolvedValue(0)
 
         render(<OrganizationsOnGithub/>)
 
@@ -87,5 +87,42 @@ describe('OrganizationsOnGithub', () => {
 
         const githubLink = screen.getByRole('link', {name: /Norwegian public organizations repo on Github/i})
         expect(githubLink).toHaveAttribute('href', 'https://github.com/MikAoJk/norwegian-public-organizations')
+    })
+
+    it('groups organizations with the same name and sums their repo counts', async () => {
+        mockGetNumberOfPublicRepos.mockImplementation((owner: string) => {
+            if (owner === 'nvdb-vegdata') return Promise.resolve(50)
+            if (owner === 'vegvesen') return Promise.resolve(30)
+            return Promise.resolve(0)
+        })
+
+        render(<OrganizationsOnGithub/>)
+
+        await waitFor(() => {
+            // Group name shown as plain text (not a standalone link)
+            expect(screen.getByText('Statens vegvesen')).toBeInTheDocument()
+            // Individual GitHub org links shown under the group
+            expect(screen.getByRole('link', {name: 'nvdb-vegdata'})).toHaveAttribute('href', 'https://github.com/nvdb-vegdata')
+            expect(screen.getByRole('link', {name: 'vegvesen'})).toHaveAttribute('href', 'https://github.com/vegvesen')
+            // Summed repo count: 50 + 30 = 80
+            expect(screen.getByText('80')).toBeInTheDocument()
+        })
+    })
+
+    it('ranks grouped organization by total repos across all its orgs', async () => {
+        mockGetNumberOfPublicRepos.mockImplementation((owner: string) => {
+            if (owner === 'navikt') return Promise.resolve(40)
+            if (owner === 'nvdb-vegdata') return Promise.resolve(50)
+            if (owner === 'vegvesen') return Promise.resolve(30)
+            return Promise.resolve(0)
+        })
+
+        render(<OrganizationsOnGithub/>)
+
+        await waitFor(() => {
+            const rows = screen.getAllByRole('row')
+            // Statens vegvesen total: 80 > navikt: 40, so grouped org ranks first
+            expect(rows[1]).toHaveTextContent('Statens vegvesen')
+        })
     })
 })


### PR DESCRIPTION
Legger til støtte for gruppering av repos pr eier, og summerer antall repos i visningen. Treffer altså de som har mer enn én GitHub-org.

<img width="1053" height="291" alt="image" src="https://github.com/user-attachments/assets/7b835737-72ab-420f-aa18-cc0b688d704d" />
